### PR TITLE
Update to install dependent packages with rosdep install command

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,17 +10,21 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>cv_bridge</build_depend>
+  <build_depend>image_publisher</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>nodelet</build_depend>
+  <build_depend>vision_msgs</build_depend>
   <run_depend>cv_bridge</run_depend>
+  <run_depend>image_publisher</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>nodelet</run_depend>
+  <run_depend>vision_msgs</run_depend>
 
   <export>
       <nodelet plugin="${prefix}/ros_deep_learning_nodelets.xml"/>


### PR DESCRIPTION
This PR updates package.xml to install dependent packages with rosdep install command as followings:

```sh
$ cd ~/catkin_ws && rosdep install -r -y --from-paths src --ignore-src
```
The dependencies that can installed by this command are described in README.

* ros-*-image-transport
* ros-*-image-publisher
* ros-*-vision-msgs