### PR TITLE
Fix for working with ZED camera image, converting bgra to bgr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   vision_msgs
   std_msgs
+  cv_bridge
 )
 
 find_package(jetson-utils REQUIRED)

--- a/src/image_converter.h
+++ b/src/image_converter.h
@@ -25,6 +25,7 @@
 
 #include <sensor_msgs/Image.h>
 
+#include <cv_bridge/cv_bridge.h>
 
 /**
  * GPU image conversion


### PR DESCRIPTION
This is a fix for working with BGRA8 images with deep learning node. The fix will convert all kinds of image encoding to bgr8. The ZED camera driver image encoding is BGRA8 when we feed image topic to deep learning node, it will throw an error. This fix will avoid that error and do the conversion.