### PR TITLE
add missing functions used to convert between colorspaces

### DIFF
--- a/src/image_converter.cpp
+++ b/src/image_converter.cpp
@@ -29,6 +29,22 @@
 #include <sensor_msgs/image_encodings.h>
 
 
+cudaError_t cudaBGR8ToRGBA32( uchar3* input, float4* output, size_t width, size_t height )
+{
+	return cudaRGB8ToRGBA32(input, output, width, height, /*swapRedBlue=*/ true);
+}
+
+cudaError_t cudaRGBA32ToBGR8( float4* input, uchar3* output, size_t width, size_t height, const float2& pixelRange )
+{
+	return cudaRGBA32ToRGB8(input, output, width, height, /*swapRedBlue=*/ true, pixelRange);
+}
+
+cudaError_t cudaRGBA32ToBGRA8( float4* input, uchar4* output, size_t width, size_t height, const float2& pixelRange )
+{
+	return cudaRGBA32ToRGBA8(input, output, width, height, /*swapRedBlue=*/ true, pixelRange);
+}
+
+
 // constructor
 imageConverter::imageConverter()
 {

--- a/src/image_converter.h
+++ b/src/image_converter.h
@@ -23,9 +23,18 @@
 #ifndef __ROS_DEEP_LEARNING_IMAGE_CONVERTER_H_
 #define __ROS_DEEP_LEARNING_IMAGE_CONVERTER_H_
 
+#include <cuda_runtime.h>
+
 #include <sensor_msgs/Image.h>
 
 
+/**
+ * Complete functions missing from <jetson-utils/cudaRGB.h>
+ */
+
+cudaError_t cudaBGR8ToRGBA32( uchar3* input, float4* output, size_t width, size_t height );
+cudaError_t cudaRGBA32ToBGR8( float4* input, uchar3* output, size_t width, size_t height, const float2& pixelRange=make_float2(0,255) );
+cudaError_t cudaRGBA32ToBGRA8( float4* input, uchar4* output, size_t width, size_t height, const float2& pixelRange=make_float2(0,255) );
 /**
  * GPU image conversion
  */

--- a/src/image_converter.h
+++ b/src/image_converter.h
@@ -33,8 +33,12 @@
  */
 
 cudaError_t cudaBGR8ToRGBA32( uchar3* input, float4* output, size_t width, size_t height );
+
 cudaError_t cudaRGBA32ToBGR8( float4* input, uchar3* output, size_t width, size_t height, const float2& pixelRange=make_float2(0,255) );
+
 cudaError_t cudaRGBA32ToBGRA8( float4* input, uchar4* output, size_t width, size_t height, const float2& pixelRange=make_float2(0,255) );
+
+
 /**
  * GPU image conversion
  */


### PR DESCRIPTION
ros_deep_learning [requires `cudaBGR8ToRGBA32()`](https://github.com/dusty-nv/ros_deep_learning/blob/df681de/src/image_converter.cpp#L84), while jetson-inference [only offers `cudaRGB8ToRGBA32()`](https://github.com/dusty-nv/jetson-utils/blob/1e0bc57/cuda/cudaRGB.h#L152) with parameter `swapRedBlue`, so we need to make a function to bridge them, or `catkin_make` would raise an error.