### PR TITLE
minor adjustments: use ROS_INFO(), and publish timestamped messages

### DIFF
--- a/src/node_detectnet.cpp
+++ b/src/node_detectnet.cpp
@@ -85,8 +85,8 @@ void img_callback( const sensor_msgs::ImageConstPtr& input )
 		{
 			detectNet::Detection* det = detections + n;
 
-			printf("object %i class #%u (%s)  confidence=%f\n", n, det->ClassID, net->GetClassDesc(det->ClassID), det->Confidence);
-			printf("object %i bounding box (%f, %f)  (%f, %f)  w=%f  h=%f\n", n, det->Left, det->Top, det->Right, det->Bottom, det->Width(), det->Height()); 
+			ROS_INFO("object %i class #%u (%s)  confidence=%f\n", n, det->ClassID, net->GetClassDesc(det->ClassID), det->Confidence);
+			ROS_INFO("object %i bounding box (%f, %f)  (%f, %f)  w=%f  h=%f\n", n, det->Left, det->Top, det->Right, det->Bottom, det->Width(), det->Height());
 			
 			// create a detection sub-message
 			vision_msgs::Detection2D detMsg;
@@ -111,6 +111,9 @@ void img_callback( const sensor_msgs::ImageConstPtr& input )
 			detMsg.results.push_back(hyp);
 			msg.detections.push_back(detMsg);
 		}
+
+		// populate timestamp filed in header
+		msg.header.stamp = ros::Time::now();
 
 		// publish the detection message
 		detection_pub->publish(msg);

--- a/src/node_imagenet.cpp
+++ b/src/node_imagenet.cpp
@@ -79,6 +79,9 @@ void img_callback( const sensor_msgs::ImageConstPtr& input )
 		obj.score = confidence;
 
 		msg.results.push_back(obj);	// TODO optionally add source image to msg
+
+		// populate timestamp in header field
+		msg.header.stamp = ros::Time::now();
 	
 		// publish the classification message
 		classify_pub->publish(msg);

--- a/src/node_segnet.cpp
+++ b/src/node_segnet.cpp
@@ -78,6 +78,7 @@ bool publish_overlay( uint32_t width, uint32_t height )
 		return false;
 
 	// publish the message
+	msg.header.stamp = ros::Time::now();
 	overlay_pub->publish(msg);
 }
 
@@ -100,6 +101,7 @@ bool publish_mask_color( uint32_t width, uint32_t height )
 		return false;
 
 	// publish the message
+	msg.header.stamp = ros::Time::now();
 	mask_color_pub->publish(msg);
 }
 
@@ -122,6 +124,7 @@ bool publish_mask_class( uint32_t width, uint32_t height )
 		return false;
 
 	// publish the message
+	msg.header.stamp = ros::Time::now();
 	mask_class_pub->publish(msg);
 }
 


### PR DESCRIPTION
Some adjustments I personally consider helpful, but don't know whether they fit everyone, so feel free to reject this PR.

In my case, pros of timestamped message:
- you can measure latency with `rostopic delay <topic>`
- if image and detection message is published separately, you can match them up by looking into their timestamps