### PR TITLE
Add parameters in TensorNet creation function to configure input/output blob

### DIFF
--- a/src/node_detectnet.cpp
+++ b/src/node_detectnet.cpp
@@ -152,6 +152,15 @@ int main(int argc, char **argv)
 	private_nh.param<float>("mean_pixel_value", mean_pixel, mean_pixel);
 	private_nh.param<float>("threshold", threshold, threshold);
 
+	// input and output blob for DetectNet model
+	std::string input_blob = DETECTNET_DEFAULT_INPUT;
+	std::string output_cvg = DETECTNET_DEFAULT_COVERAGE;
+	std::string output_bbox = DETECTNET_DEFAULT_BBOX;
+
+	private_nh.param<std::string>("input_blob", input_blob, input_blob);
+	private_nh.param<std::string>("output_cvg", output_cvg, output_cvg);
+	private_nh.param<std::string>("output_bbox", output_bbox, output_bbox);
+
 
 	/*
 	 * load object detection network
@@ -176,7 +185,7 @@ int main(int argc, char **argv)
 		private_nh.getParam("class_labels_path", class_labels_path);
 
 		// create network using custom model paths
-		net = detectNet::Create(prototxt_path.c_str(), model_path.c_str(), mean_pixel, class_labels_path.c_str(), threshold);
+		net = detectNet::Create(prototxt_path.c_str(), model_path.c_str(), mean_pixel, class_labels_path.c_str(), threshold, input_blob.c_str(), output_cvg.c_str(), output_bbox.c_str());
 	}
 
 	if( !net )

--- a/src/node_imagenet.cpp
+++ b/src/node_imagenet.cpp
@@ -119,7 +119,14 @@ int main(int argc, char **argv)
 		use_model_name = true;
 	}
 
-	
+	// input and output blob for ImageNet model
+	std::string input_blob = IMAGENET_DEFAULT_INPUT;
+	std::string output_blob = IMAGENET_DEFAULT_OUTPUT;
+
+	private_nh.param<std::string>("input_blob", input_blob, input_blob);
+	private_nh.param<std::string>("output_blob", output_blob, output_blob);
+
+
 	/*
 	 * load image recognition network
 	 */
@@ -140,7 +147,7 @@ int main(int argc, char **argv)
 	else
 	{
 		// create network using custom model paths
-		net = imageNet::Create(prototxt_path.c_str(), model_path.c_str(), NULL, class_labels_path.c_str());
+		net = imageNet::Create(prototxt_path.c_str(), model_path.c_str(), NULL, class_labels_path.c_str(), input_blob.c_str(), output_blob.c_str());
 	}
 
 	if( !net )

--- a/src/node_segnet.cpp
+++ b/src/node_segnet.cpp
@@ -201,6 +201,13 @@ int main(int argc, char **argv)
 	overlay_filter = segNet::FilterModeFromStr(overlay_filter_str.c_str(), segNet::FILTER_LINEAR);
 	mask_filter    = segNet::FilterModeFromStr(mask_filter_str.c_str(), segNet::FILTER_LINEAR);
 
+	// input and output blob for SegNet model
+	std::string input_blob = SEGNET_DEFAULT_INPUT;
+	std::string output_blob = SEGNET_DEFAULT_OUTPUT;
+
+	private_nh.param<std::string>("input_blob", input_blob, input_blob);
+	private_nh.param<std::string>("output_blob", output_blob, output_blob);
+
 
 	/*
 	 * load segmentation network
@@ -225,7 +232,7 @@ int main(int argc, char **argv)
 		private_nh.getParam("class_labels_path", class_labels_path);
 
 		// create network using custom model paths
-		net = segNet::Create(prototxt_path.c_str(), model_path.c_str(), class_labels_path.c_str(), class_colors_path.c_str());
+		net = segNet::Create(prototxt_path.c_str(), model_path.c_str(), class_labels_path.c_str(), class_colors_path.c_str(), input_blob.c_str(), output_blob.c_str());
 	}
 
 	if( !net )


### PR DESCRIPTION
For example, in the command-line utility provided by `jetson-inference`, you can:
```
detectnet --input-blob=input_0 --output-cvg=scores --output-bbox=boxes ...
```
And now in ROS, you can do the same thing by:
```
rosrun ros_deep_learning detectnet _input_blob:=input_0 _output_cvg:=scores _output_bbox:=boxes ...
```