### PR TITLE
Add subscriber_queue_length parameter

### DIFF
--- a/src/node_detectnet.cpp
+++ b/src/node_detectnet.cpp
@@ -181,6 +181,8 @@ int main(int argc, char **argv)
 	float mean_pixel = 0.0f;
 	float threshold  = DETECTNET_DEFAULT_THRESHOLD;
 
+	int subscriber_queue_length = 5;
+
 	ROS_DECLARE_PARAMETER("model_name", model_name);
 	ROS_DECLARE_PARAMETER("model_path", model_path);
 	ROS_DECLARE_PARAMETER("prototxt_path", prototxt_path);
@@ -191,6 +193,7 @@ int main(int argc, char **argv)
 	ROS_DECLARE_PARAMETER("overlay_flags", overlay_str);
 	ROS_DECLARE_PARAMETER("mean_pixel_value", mean_pixel);
 	ROS_DECLARE_PARAMETER("threshold", threshold);
+	ROS_DECLARE_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 
 
 	/*
@@ -206,6 +209,7 @@ int main(int argc, char **argv)
 	ROS_GET_PARAMETER("overlay_flags", overlay_str);
 	ROS_GET_PARAMETER("mean_pixel_value", mean_pixel);
 	ROS_GET_PARAMETER("threshold", threshold);
+	ROS_GET_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 
 	overlay_flags = detectNet::OverlayFlagsFromStr(overlay_str.c_str());
 
@@ -301,7 +305,7 @@ int main(int argc, char **argv)
 	/*
 	 * subscribe to image topic
 	 */
-	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", 5, img_callback);
+	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", subscriber_queue_length, img_callback);
 
 	
 	/*

--- a/src/node_imagenet.cpp
+++ b/src/node_imagenet.cpp
@@ -159,12 +159,15 @@ int main(int argc, char **argv)
 	std::string input_blob = IMAGENET_DEFAULT_INPUT;
 	std::string output_blob = IMAGENET_DEFAULT_OUTPUT;
 
+	int subscriber_queue_length = 5;
+
 	ROS_DECLARE_PARAMETER("model_name", model_name);
 	ROS_DECLARE_PARAMETER("model_path", model_path);
 	ROS_DECLARE_PARAMETER("prototxt_path", prototxt_path);
 	ROS_DECLARE_PARAMETER("class_labels_path", class_labels_path);
 	ROS_DECLARE_PARAMETER("input_blob", input_blob);
 	ROS_DECLARE_PARAMETER("output_blob", output_blob);
+	ROS_DECLARE_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 
 
 	/*
@@ -176,6 +179,7 @@ int main(int argc, char **argv)
 	ROS_GET_PARAMETER("class_labels_path", class_labels_path);
 	ROS_GET_PARAMETER("input_blob", input_blob);
 	ROS_GET_PARAMETER("output_blob", output_blob);
+	ROS_GET_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 
 	
 	/*
@@ -271,7 +275,7 @@ int main(int argc, char **argv)
 	/*
 	 * subscribe to image topic
 	 */
-	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", 5, img_callback);
+	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", subscriber_queue_length, img_callback);
 
 
 	/*

--- a/src/node_segnet.cpp
+++ b/src/node_segnet.cpp
@@ -187,6 +187,8 @@ int main(int argc, char **argv)
 
 	float overlay_alpha = 180.0f;
 
+	int subscriber_queue_length = 5;
+
 	ROS_DECLARE_PARAMETER("model_name", model_name);
 	ROS_DECLARE_PARAMETER("model_path", model_path);
 	ROS_DECLARE_PARAMETER("prototxt_path", prototxt_path);
@@ -197,6 +199,7 @@ int main(int argc, char **argv)
 	ROS_DECLARE_PARAMETER("mask_filter", mask_filter_str);
 	ROS_DECLARE_PARAMETER("overlay_filter", overlay_filter_str);
 	ROS_DECLARE_PARAMETER("overlay_alpha", overlay_alpha);
+	ROS_DECLARE_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 	
 	/*
 	 * retrieve parameters
@@ -211,6 +214,7 @@ int main(int argc, char **argv)
 	ROS_GET_PARAMETER("mask_filter", mask_filter_str);
 	ROS_GET_PARAMETER("overlay_filter", overlay_filter_str);
 	ROS_GET_PARAMETER("overlay_alpha", overlay_alpha);
+	ROS_GET_PARAMETER("subscriber_queue_length", subscriber_queue_length);
 
 	overlay_filter = segNet::FilterModeFromStr(overlay_filter_str.c_str(), segNet::FILTER_LINEAR);
 	mask_filter    = segNet::FilterModeFromStr(mask_filter_str.c_str(), segNet::FILTER_LINEAR);
@@ -318,7 +322,7 @@ int main(int argc, char **argv)
 	/*
 	 * subscribe to image topic
 	 */
-	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", 5, img_callback);
+	auto img_sub = ROS_CREATE_SUBSCRIBER(sensor_msgs::Image, "image_in", subscriber_queue_length, img_callback);
 
 	
 	/*


### PR DESCRIPTION
Allow the user to set the length of the image subscription queue via a parameter. This is useful if the user would like to optimize the queue length for latency or throughput.