### PR TITLE
Add source image header to detectnet and imagenet detections

### DIFF
--- a/src/node_detectnet.cpp
+++ b/src/node_detectnet.cpp
@@ -141,6 +141,10 @@ void img_callback( const sensor_msgs::ImageConstPtr input )
 			hyp.score = det->Confidence;
 
 			detMsg.results.push_back(hyp);
+
+			// add image header for detection traceability
+			detMsg.source_img.header = input->header;
+
 			msg.detections.push_back(detMsg);
 		}
 

--- a/src/node_imagenet.cpp
+++ b/src/node_imagenet.cpp
@@ -119,6 +119,9 @@ void img_callback( const sensor_msgs::ImageConstPtr input )
 		obj.id    = img_class;
 		obj.score = confidence;
 
+		// add image header for detection traceability
+		msg.source_img.header = input->header;
+
 		msg.results.push_back(obj);	// TODO optionally add source image to msg
 	
 		// populate timestamp in header field


### PR DESCRIPTION
Insert the header of the source image into the detection message. This adds traceability to the detection message and allows it to be associated to the source image at a later stage.